### PR TITLE
fix for hostnames with "-" : do not double encode "-"

### DIFF
--- a/emacsclient.py
+++ b/emacsclient.py
@@ -26,7 +26,7 @@ sock = socket.socket()
 sock.connect((host, int(port)))
 
 pwd = os.getcwd()
-tramp_args = [client_auth, '-dir', quote(tramp_prefix + pwd)]
+tramp_args = [client_auth, '-dir', tramp_prefix + quote(pwd)]
 if nowait:
     tramp_args.append('-nowait')
 
@@ -35,7 +35,7 @@ for arg in args:
         tramp_args.extend(['-position', quote(arg)])
     else:
         tramp_args.extend(
-            ['-file', quote(tramp_prefix + os.path.join(pwd, arg))])
+            ['-file', tramp_prefix + quote(os.path.join(pwd, arg))])
 
 sock.sendall(' '.join(tramp_args) + '\n')
 buffer = ''

--- a/emacsclient.py
+++ b/emacsclient.py
@@ -5,11 +5,11 @@ import socket
 import sys
 
 quote_map = {'&': '&&', '-': '&-', '\n': '&n', ' ': '&_'}
-reverse_quote_map = {v: k for v, k in quote_map.iteritems()}
+reverse_quote_map = {v: k for k, v in quote_map.iteritems()}
 def quote(s):
     return re.sub(r'[-&\n ]', lambda m: quote_map[m.group()], s)
 def unquote(s):
-    return re.sub(r'&[-&n_]', lambda m: quote_map[m.group()], s)
+    return re.sub(r'&[-&n_]', lambda m: reverse_quote_map[m.group()], s)
 
 nowait = False
 if sys.argv[1:2] == ['-n']:


### PR DESCRIPTION
The pull request also includes a fix for "unquote" which is unused. I tried to use it and did not understand why it failed...
Anyway, the fix for double encoding does not "unquote" :)
